### PR TITLE
Remove edges in 'Documentation Tree Panel' tree

### DIFF
--- a/application-documentation-ui/src/main/resources/Documentation/Code/DocumentationTreePanel.xml
+++ b/application-documentation-ui/src/main/resources/Documentation/Code/DocumentationTreePanel.xml
@@ -126,7 +126,7 @@
   #panelheader($services.localization.render('documentation.panel.navigation.title'))
   ## Escape special characters in macro parameter values.
   #set ($openToDoc = $doc.documentReference.toString().replaceAll('([~"])', '~$1'))
-  {{tree reference="Documentation.Code.DocumentationTreeSource" root="document:Documentation.WebHome" icons="false" openTo="document:$openToDoc" links="true" /}}
+  {{tree reference="Documentation.Code.DocumentationTreeSource" root="document:Documentation.WebHome" edges="false" icons="false" openTo="document:$openToDoc" links="true" /}}
   #panelfooter()
 {{/velocity}}</content>
     </property>


### PR DESCRIPTION
The panel works better without the edges:
- It matches the panel from the default wiki application which also has no edges
- Text is slightly smaller in this case so a lot more can fit in the relatively small panel
- Long page titles get linebreak instead of extending outside of the panel